### PR TITLE
Favor trailing dot for multi-line chaining of methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,27 +445,10 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="consistent-multi-line-chains"></a>
-    Adopt a consistent multi-line method chaining style. There are two
-    popular styles in the Ruby community, both of which are considered
-    good - leading `.` (Option A) and trailing `.` (Option B).
+    When continuing a chained method invocation on another line,
+    include the `.` on the first line to indicate that the expression
+    continues.
 <sup>[[link](#consistent-multi-line-chains)]</sup>
-
-  * **(Option A)** When continuing a chained method invocation on
-    another line keep the `.` on the second line.
-
-    ```Ruby
-    # bad - need to consult first line to understand second line
-    one.two.three.
-      four
-
-    # good - it's immediately clear what's going on the second line
-    one.two.three
-      .four
-    ```
-
-  * **(Option B)** When continuing a chained method invocation on another line,
-    include the `.` on the first line to indicate that the
-    expression continues.
 
     ```Ruby
     # bad - need to read ahead to the second line to know that the chain continues
@@ -476,9 +459,6 @@ Translations of the guide are available in the following languages:
     one.two.three.
       four
     ```
-
-  A discussion on the merits of both alternative styles can be found
-  [here](https://github.com/bbatsov/ruby-style-guide/pull/176).
 
 * <a name="no-double-indent"></a>
     Align the parameters of a method call if they span more than one


### PR DESCRIPTION
- Pro:
  - Current code is written like this
  - Consistent with `||`, `,` etc.
  - From https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-20421523:
    
    > Leading dots are an antipattern:
    > - They require the continuation to be present at precisely next line. (I.e. you cannot put more than one in-line comment in between.)
    > - Most importantly, code written with leading dots cannot be copied and pasted to irb/pry.
- Contra: 
  - looks weird, less organized
  - Commenting out works with leading dots
